### PR TITLE
Add support for UK banks

### DIFF
--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -7,7 +7,7 @@ module SEPA
     attr_accessor :name, :iban, :bic, :account_number
     convert :name, to: :text
 
-    validates_length_of :name, within: 1..70
+    validates_length_of :name, within: 1..70, allow_nil: true
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})

--- a/lib/sepa_king/account.rb
+++ b/lib/sepa_king/account.rb
@@ -4,11 +4,10 @@ module SEPA
     include ActiveModel::Validations
     extend Converter
 
-    attr_accessor :name, :iban, :bic
+    attr_accessor :name, :iban, :bic, :account_number
     convert :name, to: :text
 
     validates_length_of :name, within: 1..70
-    validates_presence_of :iban
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
 
     def initialize(attributes = {})

--- a/lib/sepa_king/message.rb
+++ b/lib/sepa_king/message.rb
@@ -63,9 +63,9 @@ module SEPA
       raise ArgumentError.new("Schema #{schema_name} is unknown!") unless self.known_schemas.include?(schema_name)
 
       case schema_name
-        when PAIN_001_002_03, PAIN_008_002_02, PAIN_001_001_03, PAIN_001_001_03_CH_02
+        when PAIN_001_002_03, PAIN_008_002_02, PAIN_001_001_03_CH_02
           account.bic.present? && transactions.all? { |t| t.schema_compatible?(schema_name) }
-        when PAIN_001_003_03, PAIN_008_003_02, PAIN_008_001_02
+        when PAIN_001_001_03, PAIN_001_003_03, PAIN_008_003_02, PAIN_008_001_02
           transactions.all? { |t| t.schema_compatible?(schema_name) }
       end
     end

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -11,6 +11,7 @@ module SEPA
     # Find groups of transactions which share the same values of some attributes
     def transaction_group(transaction)
       { requested_date: transaction.requested_date,
+        local_instrument: transaction.local_instrument,
         batch_booking: transaction.batch_booking,
         service_level: transaction.service_level,
         category_purpose: transaction.category_purpose,
@@ -37,6 +38,11 @@ module SEPA
             if group[:category_purpose]
               builder.CtgyPurp do
                 builder.Cd(group[:category_purpose])
+              end
+            end
+            if group[:local_instrument]
+              builder.LclInstrm do
+                builder.Prtry(group[:local_instrument])
               end
             end
           end

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -176,6 +176,14 @@ module SEPA
 
           end
         end
+
+        if transaction.purpose # short form advice
+          builder.Purp do
+            builder.Prtry(transaction.purpose)
+          end
+        end
+
+        # OCR could be added here
         if transaction.remittance_information
           builder.RmtInf do
             builder.Ustrd(transaction.remittance_information)

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -48,7 +48,7 @@ module SEPA
           end
           builder.ReqdExctnDt(group[:requested_date].iso8601)
           builder.Dbtr do
-            builder.Nm(group[:account].name)
+            builder.Nm(group[:account].name) if group[:account].name
             builder.Id do
               builder.OrgId do
                 builder.Othr do
@@ -118,7 +118,7 @@ module SEPA
               builder.ClrSysMmbId do
                 builder.ClrSysId do
                   builder.Cd(transaction.clearing_code)
-                end
+                end if transaction.clearing_code
                 builder.MmbId(transaction.clearing_bank_identifier)
               end
             end

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -56,7 +56,13 @@ module SEPA
           end
           builder.DbtrAcct do
             builder.Id do
-              builder.IBAN(group[:account].iban)
+              if group[:account].iban
+                builder.IBAN(group[:account].iban)
+              elsif group[:account].account_number
+                builder.Othr do
+                  builder.Id(group[:account].account_number)
+                end
+              end
             end
           end
           builder.DbtrAgt do
@@ -161,14 +167,16 @@ module SEPA
               builder.IBAN(transaction.iban)
             end
 
-            if transaction.bban
+            if transaction.account_number
               builder.Othr do
-                builder.Id(transaction.bban)
-                builder.SchmeNm do
-                  if transaction.bban_proprietary
-                    builder.Prtry(transaction.bban_proprietary)
-                  else
-                    builder.Cd("BBAN")
+                builder.Id(transaction.account_number)
+                if transaction.account_number_proprietary
+                  builder.SchmeNm do
+                    builder.Prtry(transaction.account_number_proprietary)
+                  end
+                elsif transaction.account_number_code
+                  builder.SchmeNm do
+                    builder.Cd(transaction.account_number_code)
                   end
                 end
               end

--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -177,16 +177,30 @@ module SEPA
           end
         end
 
-        if transaction.purpose # short form advice
-          builder.Purp do
-            builder.Prtry(transaction.purpose)
-          end
-        end
-
-        # OCR could be added here
         if transaction.remittance_information
           builder.RmtInf do
             builder.Ustrd(transaction.remittance_information)
+          end
+        elsif transaction.structured_remittance_information # change to something international
+          builder.RmtInf do
+            builder.Strd do
+              builder.CdtrRefInf do
+                builder.Tp do
+                  builder.CdOrPrtry do
+                    if transaction.structured_remittance_information_code
+                      builder.Cd(transaction.structured_remittance_information_code)
+                    else
+                      builder.Prtry(transaction.structured_remittance_information)
+                    end
+                  end
+                end
+                builder.Ref(transaction.structured_remittance_information) if transaction.structured_remittance_information_code
+              end
+            end
+          end
+        elsif transaction.purpose
+          builder.Purp do
+            builder.Prtry(transaction.purpose)
           end
         end
       end

--- a/lib/sepa_king/transaction.rb
+++ b/lib/sepa_king/transaction.rb
@@ -22,7 +22,8 @@ module SEPA
                   :batch_booking,
                   :currency,
                   :debtor_address,
-                  :creditor_address
+                  :creditor_address,
+                  :local_instrument
 
     convert :name, :instruction, :reference, :remittance_information, to: :text
     convert :amount, to: :decimal
@@ -32,6 +33,7 @@ module SEPA
     validates_length_of :instruction, within: 1..35, allow_nil: true
     validates_length_of :reference, within: 1..35, allow_nil: true
     validates_length_of :remittance_information, within: 1..140, allow_nil: true
+    validates_length_of :local_instrument, within: 1..35, allow_nil: true
     validates_numericality_of :amount, greater_than: 0
     validates_presence_of :requested_date
     validates_inclusion_of :batch_booking, :in => [true, false]

--- a/lib/sepa_king/transaction.rb
+++ b/lib/sepa_king/transaction.rb
@@ -9,8 +9,9 @@ module SEPA
     attr_accessor :name,
                   :iban,
                   :bic,
-                  :bban, # bankgiro 5748964
-                  :bban_proprietary, # BGNR
+                  :account_number, # bankgiro 5748964
+                  :account_number_proprietary, # BGNR
+                  :account_number_code,
                   :clearing_code, # SESBA
                   :clearing_bank_identifier, # 9960
                   :amount,
@@ -35,8 +36,8 @@ module SEPA
     validates_presence_of :requested_date
     validates_inclusion_of :batch_booking, :in => [true, false]
     validates_with BICValidator, IBANValidator, message: "%{value} is invalid"
-    validates :iban, presence: true, unless: :bban
-    validates :bban, presence: true, unless: :iban
+    validates :iban, presence: true, unless: :account_number
+    validates :account_number, presence: true, unless: :iban
 
     def initialize(attributes = {})
       attributes.each do |name, value|

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -5,11 +5,15 @@ module SEPA
                   :creditor_address,
                   :category_purpose,
                   :debtor_account,
-                  :purpose
+                  :purpose,
+                  :structured_remittance_information,
+                  :structured_remittance_information_code
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
+    validates_inclusion_of :structured_remittance_information_code, in: %w(RADM RPIN FXDR DISP PUOR SCOR), allow_nil: true
     validates_length_of :category_purpose, within: 1..4, allow_nil: true
     validates_length_of :purpose, within: 1..35, allow_nil: true
+    validates_length_of :structured_remittance_information, within: 1..35, allow_nil: true
 
     validate do |t|
       t.validate_requested_date_after(Date.today)

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -4,10 +4,12 @@ module SEPA
     attr_accessor :service_level,
                   :creditor_address,
                   :category_purpose,
-                  :debtor_account
+                  :debtor_account,
+                  :purpose
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
     validates_length_of :category_purpose, within: 1..4, allow_nil: true
+    validates_length_of :purpose, within: 1..35, allow_nil: true
 
     validate do |t|
       t.validate_requested_date_after(Date.today)

--- a/lib/sepa_king/transaction/direct_debit_transaction.rb
+++ b/lib/sepa_king/transaction/direct_debit_transaction.rb
@@ -6,7 +6,6 @@ module SEPA
 
     attr_accessor :mandate_id,
                   :mandate_date_of_signature,
-                  :local_instrument,
                   :sequence_type,
                   :creditor_account,
                   :original_debtor_account,

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe SEPA::Account do
     end
   end
 
-  describe :iban do
-    it 'should accept valid value' do
-      expect(SEPA::Account).to accept('DE21500500009876543210', 'PL61109010140000071219812874', for: :iban)
-    end
-
-    it 'should not accept invalid value' do
-      expect(SEPA::Account).not_to accept(nil, '', 'invalid', for: :iban)
-    end
-  end
-
   describe :bic do
     it 'should accept valid value' do
       expect(SEPA::Account).to accept('DEUTDEFF', 'DEUTDEFF500', 'SPUEDE2UXXX', for: :bic)

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SEPA::Account do
     end
 
     it 'should not accept invalid value' do
-      expect(SEPA::Account).not_to accept(nil, '', 'X' * 71, for: :name)
+      expect(SEPA::Account).not_to accept('', 'X' * 71, for: :name)
     end
   end
 

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SEPA::CreditTransfer do
     context 'for invalid debtor' do
       it 'should fail' do
         expect {
-          SEPA::CreditTransfer.new.to_xml
+          SEPA::CreditTransfer.new(name: '').to_xml
         }.to raise_error(SEPA::Error, /Name is too short/)
       end
     end

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -106,8 +106,7 @@ RSpec.describe SEPA::CreditTransfer do
                             bban_proprietary:         'BGNR',
                             amount:                   102.50,
                             reference:                'XYZ-1234/123',
-                            remittance_information:   'Rechnung vom 22.08.2013',
-                            purpose:                  'Test message'
+                            remittance_information:   'Rechnung vom 22.08.2013'
 
         sct.to_xml(SEPA::PAIN_001_001_03)
       end
@@ -124,10 +123,6 @@ RSpec.describe SEPA::CreditTransfer do
       it 'should contain <ClrSysMmbId> with expected <MmbId> and <ClrSysId/Cd>' do
         expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/CdtrAgt/FinInstnId/ClrSysMmbId/MmbId', '9900')
         expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/CdtrAgt/FinInstnId/ClrSysMmbId/ClrSysId/Cd', 'SESBA')
-      end
-
-      it 'should contain <Purp> with expected <Prtry>' do
-        expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Purp/Prtry', 'Test message')
       end
     end
 
@@ -554,6 +549,73 @@ RSpec.describe SEPA::CreditTransfer do
 
         it 'should validate against pain.001.003.03' do
           expect(subject.to_xml(SEPA::PAIN_001_003_03)).to validate_against('pain.001.003.03.xsd')
+        end
+      end
+
+      context "with structured long form reference" do
+        context "with reference code" do
+          subject do
+            sct = credit_transfer
+
+            sct.add_transaction name:                                         'Telekomiker AG',
+                                iban:                                         'DE37112589611964645802',
+                                amount:                                        102.50,
+                                structured_remittance_information:            '789456',
+                                structured_remittance_information_code:       'SCOR'
+
+            sct.to_xml(SEPA::PAIN_001_001_03)
+          end
+
+          it 'should validate against pain.001.001.03' do
+            expect(subject).to validate_against('pain.001.001.03.xsd')
+          end
+
+          it 'should contain <CdtrRefInf> with expected <Ref> and <Tp/CdOrPrtry/Cd>' do
+            expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/RmtInf/Strd/CdtrRefInf/Ref', '789456')
+            expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/RmtInf/Strd/CdtrRefInf/Tp/CdOrPrtry/Cd', 'SCOR')
+          end
+        end
+
+        context "without reference code" do
+          subject do
+            sct = credit_transfer
+
+            sct.add_transaction name:                                         'Telekomiker AG',
+                                iban:                                         'DE37112589611964645802',
+                                amount:                                        102.50,
+                                structured_remittance_information:            '789456'
+
+            sct.to_xml(SEPA::PAIN_001_001_03)
+          end
+
+          it 'should validate against pain.001.001.03' do
+            expect(subject).to validate_against('pain.001.001.03.xsd')
+          end
+
+          it 'should contain <CdtrRefInf> with expected <Tp/CdOrPrtry/Prtry>' do
+            expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/RmtInf/Strd/CdtrRefInf/Tp/CdOrPrtry/Prtry', '789456')
+          end
+        end
+      end
+
+      context "with short form reference" do
+        subject do
+          sct = credit_transfer
+
+          sct.add_transaction name:                     'Telekomiker AG',
+                              iban:                     'DE37112589611964645802',
+                              amount:                   102.50,
+                              purpose:                  'Test message'
+
+          sct.to_xml(SEPA::PAIN_001_001_03)
+        end
+
+        it 'should validate against pain.001.001.03' do
+          expect(subject).to validate_against('pain.001.001.03.xsd')
+        end
+
+        it 'should contain <Purp> with expected <Prtry>' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Purp/Prtry', 'Test message')
         end
       end
     end

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -99,14 +99,14 @@ RSpec.describe SEPA::CreditTransfer do
       subject do
         sct = credit_transfer
 
-        sct.add_transaction name:                     'Telekomiker AG',
-                            bban:                     '123456',
-                            clearing_bank_identifier: '9900', # bankgiro
-                            clearing_code:            'SESBA',
-                            bban_proprietary:         'BGNR',
-                            amount:                   102.50,
-                            reference:                'XYZ-1234/123',
-                            remittance_information:   'Rechnung vom 22.08.2013'
+        sct.add_transaction name:                       'Telekomiker AG',
+                            account_number:             '123456',
+                            clearing_bank_identifier:   '9900', # bankgiro
+                            clearing_code:              'SESBA',
+                            account_number_proprietary: 'BGNR',
+                            amount:                     102.50,
+                            reference:                  'XYZ-1234/123',
+                            remittance_information:     'Rechnung vom 22.08.2013'
 
         sct.to_xml(SEPA::PAIN_001_001_03)
       end
@@ -131,7 +131,8 @@ RSpec.describe SEPA::CreditTransfer do
         sct = credit_transfer
 
         sct.add_transaction name:                     'Telekomiker AG',
-                            bban:                     '123456',
+                            account_number:           '123456',
+                            account_number_code:      'BBAN',
                             clearing_bank_identifier: '9960', # plusgiro
                             clearing_code:            'SESBA',
                             amount:                   102.50,
@@ -161,7 +162,8 @@ RSpec.describe SEPA::CreditTransfer do
         sct = credit_transfer
 
         sct.add_transaction name:                        'Telekomiker AG',
-                            bban:                        '123456',
+                            account_number:              '123456',
+                            account_number_code:         'BBAN',
                             amount:                      102.50,
                             reference:                   'XYZ-1234/123',
                             remittance_information:      'Rechnung vom 22.08.2013'
@@ -186,9 +188,9 @@ RSpec.describe SEPA::CreditTransfer do
                                        bic:  'BANKDEFFXXX',
                                        debtor_identifier: 'Debtor Identifier AG'
 
-        sct.add_transaction name:   'Telekomiker AG',
-                            bban:   '123456',
-                            amount: 102.50
+        sct.add_transaction name:           'Telekomiker AG',
+                            account_number: '123456',
+                            amount:         102.50
 
         sct.to_xml(SEPA::PAIN_001_001_03)
       end

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -106,7 +106,8 @@ RSpec.describe SEPA::CreditTransfer do
                             bban_proprietary:         'BGNR',
                             amount:                   102.50,
                             reference:                'XYZ-1234/123',
-                            remittance_information:   'Rechnung vom 22.08.2013'
+                            remittance_information:   'Rechnung vom 22.08.2013',
+                            purpose:                  'Test message'
 
         sct.to_xml(SEPA::PAIN_001_001_03)
       end
@@ -123,6 +124,10 @@ RSpec.describe SEPA::CreditTransfer do
       it 'should contain <ClrSysMmbId> with expected <MmbId> and <ClrSysId/Cd>' do
         expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/CdtrAgt/FinInstnId/ClrSysMmbId/MmbId', '9900')
         expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/CdtrAgt/FinInstnId/ClrSysMmbId/ClrSysId/Cd', 'SESBA')
+      end
+
+      it 'should contain <Purp> with expected <Prtry>' do
+        expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Purp/Prtry', 'Test message')
       end
     end
 

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -225,12 +225,6 @@ RSpec.describe SEPA::CreditTransfer do
           expect(subject.to_xml(SEPA::PAIN_001_003_03)).to validate_against('pain.001.003.03.xsd')
         end
 
-        it 'should fail for pain.001.001.03' do
-          expect {
-            subject.to_xml(SEPA::PAIN_001_001_03)
-          }.to raise_error(SEPA::Error, /Incompatible with schema/)
-        end
-
         it 'should fail for pain.001.002.03' do
           expect {
             subject.to_xml(SEPA::PAIN_001_002_03)

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -71,4 +71,14 @@ RSpec.describe SEPA::CreditTransferTransaction do
       expect(SEPA::CreditTransferTransaction).not_to accept('', 'X' * 5, for: :category_purpose)
     end
   end
+
+  context 'Transaction Purpose: short message for creditor' do
+    it 'should allow valid value' do
+      expect(SEPA::CreditTransferTransaction).to accept(nil, 'hello', 'X' * 35, for: :purpose)
+    end
+
+    it 'should not allow invalid value' do
+      expect(SEPA::CreditTransferTransaction).not_to accept('', 'X' * 36, for: :purpose)
+    end
+  end
 end

--- a/spec/direct_debit_spec.rb
+++ b/spec/direct_debit_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe SEPA::DirectDebit do
     context 'for invalid creditor' do
       it 'should fail' do
         expect {
-          SEPA::DirectDebit.new.to_xml
+          SEPA::DirectDebit.new(name: '').to_xml
         }.to raise_error(SEPA::Error, /Name is too short/)
       end
     end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe SEPA::Message do
 
     it 'should fail with invalid account' do
       expect(subject).not_to be_valid
-      expect(subject.errors_on(:account).size).to eq(2)
+      expect(subject.errors_on(:account).size).to eq(1)
     end
 
     it 'should fail without transactions' do

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe SEPA::Message do
     subject { DummyMessage.new }
 
     it 'should fail with invalid account' do
+      subject.account.name = ''
       expect(subject).not_to be_valid
       expect(subject.errors_on(:account).size).to eq(1)
     end


### PR DESCRIPTION
Adding various improvements in order to support required minimum for BACS payments using schema 001.001.03:

- Remove IBAN and BIC validations, since they can be empty
- Remove name requirement for Debtor (sender)
- Remove clearing code requirement if it's not present
- Rename BBAN fields to account number to be international
- Add local_instrument support (same behaviour as for direct_debit)
- Add account number field support
- Add structured remittance information support (structured long form reference for receiver)
