### PR TITLE
Add CreditTransferTransaction#charge_bearer

### DIFF
--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -16,7 +16,8 @@ module SEPA
         batch_booking: transaction.batch_booking,
         service_level: transaction.service_level,
         category_purpose: transaction.category_purpose,
-        account: transaction.debtor_account || account
+        account: transaction.debtor_account || account,
+        charge_bearer: transaction.charge_bearer,
       }
     end
 
@@ -87,8 +88,8 @@ module SEPA
               end
             end
           end
-          if group[:service_level]
-            builder.ChrgBr('SLEV')
+          if group[:charge_bearer]
+            builder.ChrgBr(group[:charge_bearer])
           end
 
           transactions.each do |transaction|

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -7,7 +7,8 @@ module SEPA
                   :debtor_account,
                   :purpose,
                   :structured_remittance_information,
-                  :structured_remittance_information_code
+                  :structured_remittance_information_code,
+                  :charge_bearer
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
     validates_inclusion_of :structured_remittance_information_code, in: %w(RADM RPIN FXDR DISP PUOR SCOR), allow_nil: true
@@ -26,6 +27,9 @@ module SEPA
     def initialize(attributes = {})
       super
       self.service_level ||= 'SEPA' if self.currency == 'EUR'
+      if service_level
+        self.charge_bearer ||= 'SLEV'
+      end
     end
 
     def schema_compatible?(schema_name)

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -616,6 +616,65 @@ RSpec.describe SEPA::CreditTransfer do
       end
     end
 
+    context '#charge_bearer' do
+      let(:format) { SEPA::PAIN_001_001_03 }
+      subject { credit_transfer.to_xml(format) }
+
+      before do
+        credit_transfer.add_transaction(transaction)
+      end
+
+      context 'with a specified charge bearer' do
+        let(:transaction) do
+          {
+            name: 'Telekomiker AG',
+            iban: 'DE37112589611964645802',
+            bic: 'PBNKDEFF370',
+            amount: 102.50,
+            currency: 'CHF',
+            charge_bearer: 'SHAR',
+          }
+        end
+
+        it 'contains the specified ChrgBr' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/ChrgBr', 'SHAR')
+        end
+      end
+
+      context 'with the default charge bearer and in service_level SEPA (EUR)' do
+        let(:transaction) do
+          {
+            name: 'Telekomiker AG',
+            iban: 'DE37112589611964645802',
+            bic: 'PBNKDEFF370',
+            amount: 102.50,
+            currency: 'EUR',
+          }
+        end
+
+        it 'contains the SLEV ChrgBr' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/ChrgBr', 'SLEV')
+        end
+      end
+
+      context 'with a specified charge bearer and in service_level SEPA (EUR)' do
+        let(:transaction) do
+          {
+            name: 'Telekomiker AG',
+            iban: 'DE37112589611964645802',
+            bic: 'PBNKDEFF370',
+            amount: 102.50,
+            currency: 'EUR',
+            charge_bearer: 'SHAR',
+          }
+        end
+
+        it 'contains the SHAR ChrgBr' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/ChrgBr', 'SHAR')
+        end
+      end
+    end
+
     context 'xml_schema_header' do
       subject { credit_transfer.to_xml(format) }
 

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -81,4 +81,14 @@ RSpec.describe SEPA::CreditTransferTransaction do
       expect(SEPA::CreditTransferTransaction).not_to accept('', 'X' * 36, for: :purpose)
     end
   end
+
+  context 'Charge Bearer' do
+    it 'should allow valid value' do
+      expect(SEPA::CreditTransferTransaction).to accept('CRED', 'DEBT', 'SHAR', 'SLEV', for: :charge_bearer)
+    end
+
+    it 'should not allow invalid value' do
+      expect(SEPA::CreditTransferTransaction).to accept('FOO', '', 'BAR', for: :charge_bearer)
+    end
+  end
 end


### PR DESCRIPTION
This allows the XML to contain the `<ChrgBr>` element.

This PR moves the defaulting of the "SLEV" value to the Credit Transfer Transaction class' constructor.