### PR TITLE
Add CreditTransfer::Transaction#destination_currency

### DIFF
--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -108,7 +108,14 @@ module SEPA
           builder.EndToEndId(transaction.reference)
         end
         builder.Amt do
-          builder.InstdAmt('%.2f' % transaction.amount, Ccy: transaction.currency)
+          if transaction.destination_currency
+            builder.EqvtAmt do
+              builder.Amt('%.2f' % transaction.amount, Ccy: transaction.currency)
+              builder.CcyOfTrf(transaction.destination_currency)
+            end
+          else
+            builder.InstdAmt('%.2f' % transaction.amount, Ccy: transaction.currency)
+          end
         end
         if transaction.bic
           builder.CdtrAgt do

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -8,7 +8,8 @@ module SEPA
                   :purpose,
                   :structured_remittance_information,
                   :structured_remittance_information_code,
-                  :charge_bearer
+                  :charge_bearer,
+                  :destination_currency
 
     validates_inclusion_of :service_level, :in => %w(SEPA URGP), :allow_nil => true
     validates_inclusion_of :structured_remittance_information_code, in: %w(RADM RPIN FXDR DISP PUOR SCOR), allow_nil: true
@@ -16,6 +17,7 @@ module SEPA
     validates_length_of :category_purpose, within: 1..4, allow_nil: true
     validates_length_of :purpose, within: 1..35, allow_nil: true
     validates_length_of :structured_remittance_information, within: 1..35, allow_nil: true
+    validates_length_of :destination_currency, is: 3, allow_nil: true
 
     validate do |t|
       t.validate_requested_date_after(Date.today)

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -675,6 +675,33 @@ RSpec.describe SEPA::CreditTransfer do
       end
     end
 
+    context '#destination_currency' do
+      let(:format) { SEPA::PAIN_001_001_03 }
+      subject { credit_transfer.to_xml(format) }
+
+      before do
+        credit_transfer.add_transaction(transaction)
+      end
+
+      context 'with a destination_currency' do
+        let(:transaction) do
+          {
+            name: 'Telekomiker AG',
+            iban: 'DE37112589611964645802',
+            bic: 'PBNKDEFF370',
+            amount: 102.50,
+            currency: 'CHF',
+            destination_currency: 'EUR'
+          }
+        end
+
+        it 'contains the specified "destination currency" in <CcyOfTrf>' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Amt/EqvtAmt/Amt[@Ccy="CHF"]', '102.50')
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Amt/EqvtAmt/CcyOfTrf', 'EUR')
+        end
+      end
+    end
+
     context 'xml_schema_header' do
       subject { credit_transfer.to_xml(format) }
 

--- a/spec/credit_transfer_transaction_spec.rb
+++ b/spec/credit_transfer_transaction_spec.rb
@@ -91,4 +91,14 @@ RSpec.describe SEPA::CreditTransferTransaction do
       expect(SEPA::CreditTransferTransaction).not_to accept('FOO', '', 'BAR', for: :charge_bearer)
     end
   end
+
+  context 'destination_currency' do
+    it 'should allow valid value' do
+      expect(SEPA::CreditTransferTransaction).to accept(nil, 'EUR', 'CHF', 'USD', for: :destination_currency)
+    end
+
+    it 'should not allow invalid value' do
+      expect(SEPA::CreditTransferTransaction).not_to accept('', 'FOOP', 'BARP', for: :destination_currency)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new property `destination_currency`, which is for using the Equivalent Amount feature of the standard.