### PR TITLE
Add logic for "equivalent amount"

### DIFF
--- a/lib/sepa_king/message/credit_transfer.rb
+++ b/lib/sepa_king/message/credit_transfer.rb
@@ -108,7 +108,7 @@ module SEPA
           builder.EndToEndId(transaction.reference)
         end
         builder.Amt do
-          if transaction.destination_currency
+          if transaction.use_equivalent_amount?
             builder.EqvtAmt do
               builder.Amt('%.2f' % transaction.amount, Ccy: transaction.currency)
               builder.CcyOfTrf(transaction.destination_currency)

--- a/lib/sepa_king/transaction/credit_transfer_transaction.rb
+++ b/lib/sepa_king/transaction/credit_transfer_transaction.rb
@@ -35,6 +35,10 @@ module SEPA
       end
     end
 
+    def use_equivalent_amount?
+      destination_currency && destination_currency != currency
+    end
+
     def schema_compatible?(schema_name)
       case schema_name
       when PAIN_001_001_03

--- a/spec/credit_transfer_spec.rb
+++ b/spec/credit_transfer_spec.rb
@@ -700,6 +700,24 @@ RSpec.describe SEPA::CreditTransfer do
           expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Amt/EqvtAmt/CcyOfTrf', 'EUR')
         end
       end
+
+      context 'with a destination_currency the same as the currency' do
+        let(:transaction) do
+          {
+            name: 'Telekomiker AG',
+            iban: 'DE37112589611964645802',
+            bic: 'PBNKDEFF370',
+            amount: 102.50,
+            currency: 'EUR',
+            destination_currency: 'EUR'
+          }
+        end
+
+        it 'does not contain an "equivalent amount"' do
+          expect(subject).to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Amt/InstdAmt')
+          expect(subject).not_to have_xml('//Document/CstmrCdtTrfInitn/PmtInf/CdtTrfTxInf[1]/Amt/EqvtAmt')
+        end
+      end
     end
 
     context 'xml_schema_header' do


### PR DESCRIPTION
Allow same-value destination_currency and currency to use InstdAmt, instead of EqvtAmt.

This is an ease-of-use improvement, allowing you to always offer the destination_currency.